### PR TITLE
add missing env vars to compose.yaml, updated readme accordingly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+.idea

--- a/README.md
+++ b/README.md
@@ -17,21 +17,23 @@ Setting up environment:
 ```python
 # .env
 
-# The port the API listens on, defaults to 8080 if unset.
-API_PORT=1337
 # The username of the user postgres creates
-POSTGRES_USER="example"
+POSTGRES_USER=example
 # The password of the user postgres creates
-POSTGRES_PASSWORD="example"
+POSTGRES_PASSWORD=example
 # The postgres database name. Cannot include hyphens (postgres commits oof)
-POSTGRES_DB="example"
+POSTGRES_DB=example
 ```
 
 ```python
-# hut-finder-api/.env - must be created but can be empty
+# hut-finder-api/.env - `PORT` and `TOKEN_EXPIRY_HOURS` can be left empty
 
 # The port the API listens on, serves as a backup if the root .env isn't set
 PORT=1337
+# The key used to sign the session token
+SIGNING_KEY=example
+# The time until session token expires, defaults to 12 if missing
+TOKEN_EXPIRY_HOURS=12
 ```
 
 ## Authors 

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,8 +11,8 @@ services:
       retries: 5
     build:
       context: hut-finder-utilities
-    ports:
-      - 5432:5432
+    expose:
+      - 5432
 
   api:
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,7 +17,9 @@ services:
   api:
     environment:
       DB_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@host.docker.internal:5432/${POSTGRES_DB}"
-      PORT: ${API_PORT}
+      PORT: ${PORT}
+      SIGNING_KEY: ${SIGNING_KEY}
+      TOKEN_EXPIRY_HOURS: ${TOKEN_EXPIRY_HOURS}
     build:
       context: hut-finder-api
       target: runtime
@@ -25,4 +27,4 @@ services:
       utilities:
         condition: service_healthy
     ports:
-      - ${API_PORT}:${API_PORT}
+      - ${PORT}:${PORT}

--- a/hut-finder-api/.gitignore
+++ b/hut-finder-api/.gitignore
@@ -1,3 +1,4 @@
 hut-finder-api
 .env
 .vscode
+mod

--- a/hut-finder-api/go.mod
+++ b/hut-finder-api/go.mod
@@ -1,6 +1,6 @@
 module hut-finder-api
 
-go 1.23
+go 1.22
 
 require (
 	github.com/gin-gonic/gin v1.10.0


### PR DESCRIPTION
bumped go down to 1.22 as well since builds wouldn't compile with that